### PR TITLE
fix PDFPageProxy.getViewport obsolete parameter format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-pdf-cdn",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Lightweight PDF viewer for Vue.js using CDN",
   "repository": {
     "url": "https://github.com/leo-buneev/vue-pdf-cdn/",

--- a/src/components/VuePdf.js
+++ b/src/components/VuePdf.js
@@ -72,10 +72,10 @@ export default {
       this._page = await this._pdf.getPage(pageNum)
 
       const desiredWidth = this.$el.clientWidth
-      const viewport = this._page.getViewport(1)
+      const viewport = this._page.getViewport({ scale: 1 })
 
       const scale = desiredWidth / viewport.width
-      const scaledViewport = this._page.getViewport(scale)
+      const scaledViewport = this._page.getViewport({ scale })
 
       const canvas = this.$refs.canvas
       canvas.height = scaledViewport.height


### PR DESCRIPTION
It wasn't working with recent version of `pdfjs`.

```
Failure during downloading PDF file: Error: PDFPageProxy.getViewport is called with obsolete arguments.
    at PDFPageProxy.getViewport (VM182993 pdf.min.js:22)
    at _callee4$ (VM182528 vue-pdf-cdn.umd.js:2874)
    at tryCatch (VM182528 vue-pdf-cdn.umd.js:1420)
    at Generator.invoke [as _invoke] (VM182528 vue-pdf-cdn.umd.js:1646)
    at Generator.prototype.<computed> [as next] (VM182528 vue-pdf-cdn.umd.js:1472)
    at asyncGeneratorStep (VM182528 vue-pdf-cdn.umd.js:2585)
    at _next (VM182528 vue-pdf-cdn.umd.js:2607)
```